### PR TITLE
Don't rename ids into ids that aren't in the idmap

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,11 @@
-"use strict";
+'use strict';
 
-const safeParser = require("postcss-safe-parser");
-const selectorParser = require("postcss-selector-parser");
-const nameGenerators = require("./name-generators");
+const safeParser = require('postcss-safe-parser');
+const selectorParser = require('postcss-selector-parser');
+const nameGenerators = require('./name-generators');
 
 class MinifyClassnames {
-  constructor({ genNameClass, genNameId, filter } = {}) {
+  constructor({genNameClass, genNameId, filter} = {}) {
     this.filter = filter || /^.js-/;
     // TODO: Pass a seed for emojinamestring, make this better
     this.genNameClass = this.getNameGenerator(genNameClass, 7);
@@ -13,35 +13,51 @@ class MinifyClassnames {
     this.classMap = {};
     this.idMap = {};
   }
+
   getNameGenerator(value, seed) {
     if (value === false) {
       return false;
-    } else if (value) {
+    }
+
+    if (value) {
       return nameGenerators[value](seed);
     }
-    return nameGenerators["genName"](seed);
+
+    return nameGenerators.genName(seed);
   }
+
   isClassFiltered(className) {
-    if (this.genNameClass === false) return true;
+    if (this.genNameClass === false) {
+      return true;
+    }
+
     return this.filter.test(`.${className}`);
   }
+
   isIdFiltered(idName) {
-    if (this.genNameId === false) return true;
+    if (this.genNameId === false) {
+      return true;
+    }
+
     return this.filter.test(`#${idName}`);
   }
+
   process(tree) {
     return this.minifyElements(this.minifyStyles(tree));
   }
+
   minifyStyles(tree) {
     return tree.walk(node => {
-      if (node.tag === "style" && node.content) {
+      if (node.tag === 'style' && node.content) {
         const ast = safeParser(node.content.toString());
         this.walkRules(ast.nodes);
         node.content = [ast.toString()];
       }
+
       return node;
     });
   }
+
   minifyElements(tree) {
     return tree.walk(node => {
       if (node.attrs && node.attrs.class) {
@@ -52,14 +68,15 @@ class MinifyClassnames {
             // NOTE: This removes classes that don't match any in our CSS
             if (this.isClassFiltered(value)) {
               return value;
-            } else {
-              return this.classMap[value] || "";
             }
+
+            return this.classMap[value] || '';
           })
           .filter(Boolean)
-          .join(" ")
+          .join(' ')
           .trim();
       }
+
       if (node.attrs && node.attrs.id) {
         let ids = node.attrs.id;
         node.attrs.id = ids
@@ -67,60 +84,68 @@ class MinifyClassnames {
           .map(value => {
             if (this.isIdFiltered(value)) {
               return value;
-            } else {
-              if (!this.idMap[value]) {
-                this.idMap[value] = this.genNameId.next().value;
-              }
-              return this.idMap[value];
             }
+
+            if (!this.idMap[value]) {
+              this.idMap[value] = this.genNameId.next().value;
+            }
+
+            return this.idMap[value];
           })
-          .join(" ");
+          .join(' ');
       }
+
       if (node.attrs && node.attrs.for) {
         let htmlFor = node.attrs.for;
         if (!this.isIdFiltered(htmlFor)) {
           if (!this.idMap[htmlFor]) {
             this.idMap[htmlFor] = this.genNameId.next().value;
           }
+
           if (this.idMap[htmlFor]) {
             node.attrs.for = this.idMap[htmlFor];
           }
         }
       }
+
       if (
-        node.tag === "use" &&
-        (node.attrs["href"] || node.attrs["xlink:href"])
+        node.tag === 'use' &&
+        (node.attrs.href || node.attrs['xlink:href'])
       ) {
-        const href = node.attrs["href"] ? "href" : "xlink:href";
-        const id = node.attrs[href].substring(1);
+        const href = node.attrs.href ? 'href' : 'xlink:href';
+        const id = node.attrs[href].slice(1);
         if (!this.isIdFiltered(id)) {
           if (this.idMap[id]) {
-            node.attrs[href] = "#" + this.idMap[id];
+            node.attrs[href] = '#' + this.idMap[id];
           }
         }
       }
+
       return node;
     });
   }
+
   walkRules(nodes) {
     // TODO: nodes should be returned
     nodes.forEach(rule => {
       if (
-        rule.type === "atrule" &&
-        (rule.name === "media" || rule.name === "supports")
+        rule.type === 'atrule' &&
+        (rule.name === 'media' || rule.name === 'supports')
       ) {
         this.walkRules(rule.nodes);
-      } else if (rule.type === "rule") {
+      } else if (rule.type === 'rule') {
         selectorParser(selectors => {
           selectors.walkClasses(classNode => {
             if (this.isClassFiltered(classNode.value)) {
               return;
             }
+
             if (!this.classMap[classNode.value]) {
               this.classMap[classNode.value] = this.genNameClass.next().value;
             }
+
             classNode.setPropertyWithoutEscape(
-              "value",
+              'value',
               this.classMap[classNode.value]
             );
           });
@@ -129,9 +154,11 @@ class MinifyClassnames {
             if (this.isIdFiltered(idNode.value)) {
               return;
             }
+
             if (!this.idMap[idNode.value]) {
               this.idMap[idNode.value] = this.genNameId.next().value;
             }
+
             idNode.value = this.idMap[idNode.value];
           });
           rule.selector = selectors.toString();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
-'use strict';
+"use strict";
 
-const safeParser = require('postcss-safe-parser');
-const selectorParser = require('postcss-selector-parser');
-const nameGenerators = require('./name-generators');
+const safeParser = require("postcss-safe-parser");
+const selectorParser = require("postcss-selector-parser");
+const nameGenerators = require("./name-generators");
 
 class MinifyClassnames {
   constructor({ genNameClass, genNameId, filter } = {}) {
@@ -19,7 +19,7 @@ class MinifyClassnames {
     } else if (value) {
       return nameGenerators[value](seed);
     }
-    return nameGenerators['genName'](seed);
+    return nameGenerators["genName"](seed);
   }
   isClassFiltered(className) {
     if (this.genNameClass === false) return true;
@@ -34,7 +34,7 @@ class MinifyClassnames {
   }
   minifyStyles(tree) {
     return tree.walk(node => {
-      if (node.tag === 'style' && node.content) {
+      if (node.tag === "style" && node.content) {
         const ast = safeParser(node.content.toString());
         this.walkRules(ast.nodes);
         node.content = [ast.toString()];
@@ -53,11 +53,11 @@ class MinifyClassnames {
             if (this.isClassFiltered(value)) {
               return value;
             } else {
-              return this.classMap[value] || '';
+              return this.classMap[value] || "";
             }
           })
           .filter(Boolean)
-          .join(' ')
+          .join(" ")
           .trim();
       }
       if (node.attrs && node.attrs.id) {
@@ -74,7 +74,7 @@ class MinifyClassnames {
               return this.idMap[value];
             }
           })
-          .join(' ');
+          .join(" ");
       }
       if (node.attrs && node.attrs.for) {
         let htmlFor = node.attrs.for;
@@ -82,16 +82,21 @@ class MinifyClassnames {
           if (!this.idMap[htmlFor]) {
             this.idMap[htmlFor] = this.genNameId.next().value;
           }
-          node.attrs.for = this.idMap[htmlFor];
+          if (this.idMap[htmlFor]) {
+            node.attrs.for = this.idMap[htmlFor];
+          }
         }
       }
       if (
-        node.tag === 'use' &&
-        (node.attrs['href'] || node.attrs['xlink:href'])
+        node.tag === "use" &&
+        (node.attrs["href"] || node.attrs["xlink:href"])
       ) {
-        const href = node.attrs['href'] ? 'href' : 'xlink:href';
-        if (!this.isIdFiltered(node.attrs[href].substring(1))) {
-          node.attrs[href] = '#' + this.idMap[node.attrs[href].substring(1)];
+        const href = node.attrs["href"] ? "href" : "xlink:href";
+        const id = node.attrs[href].substring(1);
+        if (!this.isIdFiltered(id)) {
+          if (this.idMap[id]) {
+            node.attrs[href] = "#" + this.idMap[id];
+          }
         }
       }
       return node;
@@ -101,11 +106,11 @@ class MinifyClassnames {
     // TODO: nodes should be returned
     nodes.forEach(rule => {
       if (
-        rule.type === 'atrule' &&
-        (rule.name === 'media' || rule.name === 'supports')
+        rule.type === "atrule" &&
+        (rule.name === "media" || rule.name === "supports")
       ) {
         this.walkRules(rule.nodes);
-      } else if (rule.type === 'rule') {
+      } else if (rule.type === "rule") {
         selectorParser(selectors => {
           selectors.walkClasses(classNode => {
             if (this.isClassFiltered(classNode.value)) {
@@ -115,8 +120,8 @@ class MinifyClassnames {
               this.classMap[classNode.value] = this.genNameClass.next().value;
             }
             classNode.setPropertyWithoutEscape(
-              'value',
-              this.classMap[classNode.value],
+              "value",
+              this.classMap[classNode.value]
             );
           });
 


### PR DESCRIPTION
Sometimes this generates code like `<use href="#undefined">`. This change tries to avoid those situations.